### PR TITLE
fixed causeMatches

### DIFF
--- a/mule-user-guide/v/3.5/choice-exception-strategy.adoc
+++ b/mule-user-guide/v/3.5/choice-exception-strategy.adoc
@@ -36,20 +36,21 @@ a|
 
 Checks that the exception is an instance of ExceptionType
 
- |`#[exception.causedBy(java.lang.IllegalArgumentException)]` 
+|`#[exception.causedBy(java.lang.IllegalArgumentException)]` 
 a|
 `#[exception.causedExactlyBy(ExceptionType)]`
 
 Checks that the exception exactly matches the ExceptionType
 
- |`#[exception.causedExactlyBy(java.net.SocketTimeoutException)]`
+|`#[exception.causedExactlyBy(java.net.SocketTimeoutException)]`
 a|
-`#[exception.causeMatches(Regex)]`
+`#[exception.causeMatches(String)]`
 
-Checks that the exception type matches a particular regular expression (Regex)
+Checks that the exception type matches a particular regular expression (Regex) String
 
- |`#[exception.causeMatches(*BusinessException)]`
+|`#[exception.causeMatches('*BusinessException')]`
 |===
+
 
 == Configuring a Choice Exception Strategy
 


### PR DESCRIPTION
error goes back to  Mule 3.3.1 when causeMatches was first added.